### PR TITLE
Fix URL in git clone installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A GNOME Shell extension that allows you to record audio from your microphone, tr
 
 1. Clone this repository directly into your extensions directory:
 ```bash
-git clone https://github.com/opreto/whisper-transcriber.git ~/.local/share/gnome-shell/extensions/whisper-transcriber@opreto.com
+git clone https://github.com/alanpca/gnome-whisper-transcriber.git ~/.local/share/gnome-shell/extensions/whisper-transcriber@opreto.com
 ```
 
 2. Compile the schema:


### PR DESCRIPTION
The `git clone` install step is pointing to a private repo. I fixed it to point to the public repo.